### PR TITLE
Fix parameters reordering.

### DIFF
--- a/src/parser/services.rs
+++ b/src/parser/services.rs
@@ -141,11 +141,11 @@ impl Type {
 
 pub fn extract_param_defaults(
     endpoints: &HashMap<String, EndpointData>,
-) -> Vec<(String, Vec<(String, String)>)> {
-    let mut result = Vec::new();
+) -> HashMap<String, HashMap<String, String>> {
+    let mut result = HashMap::new();
 
     for (method_id, endpoint_data) in endpoints {
-        let mut param_vec = Vec::new();
+        let mut param_map = HashMap::new();
         for (param_name, param_value) in &endpoint_data.params {
             let value_str = match param_value {
                 ParamValue::String(s) => s.clone(),
@@ -154,9 +154,9 @@ pub fn extract_param_defaults(
                 ParamValue::Array(arr) => format!("{:?}", arr),
                 ParamValue::Object(obj) => format!("{:?}", obj),
             };
-            param_vec.push((param_name.clone(), value_str));
+            param_map.insert(param_name.to_string(), value_str);
         }
-        result.push((method_id.clone(), param_vec));
+        result.insert(method_id.to_string(), param_map);
     }
 
     result

--- a/src/tui/app.rs
+++ b/src/tui/app.rs
@@ -13,7 +13,11 @@ use std::sync::Arc;
 use tokio::sync::Mutex;
 use tokio::time::{self, Duration};
 
-pub async fn run(endpoint_names: Vec<String>, endpoint_data: HashMap<String, EndpointMetadata>, param_defaults: Vec<(String, Vec<(String, String)>)>) -> Result<()> {
+pub async fn run(
+    endpoint_names: Vec<String>,
+    endpoint_data: HashMap<String, EndpointMetadata>,
+    param_defaults: HashMap<String, HashMap<String, String>>,
+) -> Result<()> {
     // Set up terminal in raw mode
     enable_raw_mode()?;
     let mut stdout = io::stdout();

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -48,7 +48,7 @@ pub struct AppState {
     pub service_name: Option<String>,
     pub params: Vec<ParameterMetadata>,
     pub param_values: Vec<String>,
-    pub param_defaults: Vec<(String, Vec<(String, String)>)>,
+    pub param_defaults: HashMap<String, HashMap<String, String>>,
     pub json_view_mode: JsonViewMode,
     pub json_data: Option<String>,
     pub endpoints: Vec<String>,
@@ -59,7 +59,11 @@ pub struct AppState {
 }
 
 impl AppState {
-    pub fn new(endpoint_names: Vec<String>, endpoint_data: HashMap<String, EndpointMetadata>, param_defaults: Vec<(String, Vec<(String, String)>)>) -> Self {
+    pub fn new(
+        endpoint_names: Vec<String>,
+        endpoint_data: HashMap<String, EndpointMetadata>,
+        param_defaults: HashMap<String, HashMap<String, String>>,
+    ) -> Self {
         Self {
             client: None,
             current_block: AppBlock::Settings,
@@ -281,18 +285,18 @@ impl AppState {
                 self.method_id = Some(metadata.method_id);
                 self.service_name = Some(metadata.service_name.clone());
     
-                // Sort params by their names
-                self.params = {
-                    let mut sorted_params = metadata.params.clone();
-                    sorted_params.sort_by(|a, b| a.name.cmp(&b.name));
-                    sorted_params
-                };
-    
+                // Do not sort params by their names
+                self.params = metadata.params.clone();
+
                 // Check if there are default values for this method_id
-                if let Some((_, defaults)) = self.param_defaults.iter().find(|(id, _)| *id == metadata.method_id.to_string()) {
+                if let Some((_, defaults)) = self
+                    .param_defaults
+                    .iter()
+                    .find(|(id, _)| **id == metadata.method_id.to_string())
+                {
                     // Create a map of default values for easy lookup
-                    let default_map: HashMap<_, _> = defaults.iter().cloned().collect();
-    
+                    let default_map: HashMap<_, _> = defaults.clone();
+
                     // Populate param_values with either the default value or an empty string
                     self.param_values = self.params.iter()
                         .map(|param| {


### PR DESCRIPTION
Before: parameters were sorted by name and send
to the server. This coused deserialization issues.

After: use HashMap to ignore the order in Vec and sed parameter according to their definition in endpoints.